### PR TITLE
Shift columns left and fill missing data

### DIFF
--- a/script.js
+++ b/script.js
@@ -300,7 +300,12 @@
   });
 
   weekStartInput.addEventListener('change', () => {
-    state.weekStartIso = weekStartInput.value || null;
+    // Normalize any picked date to Monday to avoid off-by-one day shifts
+    if (weekStartInput.value) {
+      setWeekStartFromDate(weekStartInput.value);
+    } else {
+      state.weekStartIso = null;
+    }
   });
 
   btnTransform.addEventListener('click', () => {


### PR DESCRIPTION
Normalize the `weekStart` input to Monday to correctly align `HOURS` and `EXTERNALCOMMENTS` columns.

The previous implementation allowed `state.weekStartIso` to be set to any day of the week selected by the user, which caused an off-by-one error in column mapping when generating the CSV output. This resulted in `HOURS` and `EXTERNALCOMMENTS` columns being empty and subsequent data shifting left. By normalizing the input to always represent the Monday of the selected week, the day indexing for data extraction is consistently aligned.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d9ee612-88f0-4b5a-8d4d-89e5dce68fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2d9ee612-88f0-4b5a-8d4d-89e5dce68fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

