### PR TITLE
Set monday as first day of week

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Workforce ➜ Dynamics Time Import</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   </head>
   <body>
     <header class="container">
@@ -23,7 +24,7 @@
         <h2>2) Select Week</h2>
         <div class="week-row">
           <label for="weekStart">Week starting (Mon):</label>
-          <input type="date" id="weekStart" />
+          <input type="text" id="weekStart" />
           <button id="btnAutofillWeek" class="secondary">Autofill from file</button>
         </div>
       </section>
@@ -53,6 +54,7 @@
     <script src="https://cdn.jsdelivr.net/npm/dayjs@1/plugin/isoWeek.min.js"></script>
     <script>dayjs.extend(window.dayjs_plugin_isoWeek)</script>
     <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
     <script src="script.js"></script>
   </body>
   </html>

--- a/script.js
+++ b/script.js
@@ -27,6 +27,20 @@
     ...COMMENT_COLS,
   ];
 
+  // Initialize calendar widget with Monday as first day of week
+  let weekPicker = null;
+  if (window.flatpickr) {
+    weekPicker = window.flatpickr(weekStartInput, {
+      dateFormat: 'Y-m-d',
+      allowInput: true,
+      disableMobile: true,
+      locale: { firstDayOfWeek: 1 },
+      onChange: (_selectedDates, dateStr) => {
+        if (dateStr) setWeekStartFromDate(dateStr);
+      },
+    });
+  }
+
   function setWeekStartFromDate(date) {
     // Force Monday as start of week using ISO week handling
     const d = dayjs(date);
@@ -34,6 +48,7 @@
     const monday = d.isoWeekday() === 1 ? d : d.isoWeekday(1);
     weekStartInput.value = monday.format('YYYY-MM-DD');
     state.weekStartIso = weekStartInput.value;
+    if (weekPicker) weekPicker.setDate(state.weekStartIso, false);
   }
 
   // No manual mapping needed; fixed columns are used


### PR DESCRIPTION
Configure the calendar widget to start weeks on Monday by integrating Flatpickr.

---
<a href="https://cursor.com/background-agent?bcId=bc-6dc9596d-5e2f-4d53-8bd4-48b9a596c2ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6dc9596d-5e2f-4d53-8bd4-48b9a596c2ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

